### PR TITLE
Fix the IOC to work with standard build system

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -25,37 +25,26 @@
 #MODULES = /path/to/modules
 #MYMODULE = $(MODULES)/my-module
 
-# If using the sequencer, point SNCSEQ at its top directory:
-#SNCSEQ = $(MODULES)/seq-ver
+#ADCORE=
+#ADSUPPORT=
+#PSCDRV=
+#QUADEM=
+#NSLS2EM=
+#STD=
 
-#
-
-STD=/epics/modules/std
-
-SUPPORT=/usr/lib/epics
+#ASYN=
+#AUTOSAVE=
+#BUSY=
+#CALC=
+#DEVIOCSTATS=
+#SSCAN=
+#STREAM=
+#SNCSEQ=
+#RECCASTER=
+#MOTOR=
 
 # EPICS_BASE should appear last so earlier modules can override stuff:
-EPICS_BASE=/usr/lib/epics
-
-# Set RULES here if you want to use build rules from somewhere
-# other than EPICS_BASE:
-#RULES = $(MODULES)/build-rules
-
-
-###
-ASYN=/usr/lib/epics
-AUTOSAVE=/usr/lib/epics
-IOCSTATS=/usr/lib/epics
-CAPUTLOG=/usr/lib/epics
-BUSY=/usr/lib/epics
-CALC=/usr/lib/epics
-#PSCDRV=$(SUPPORT)/pscdrv
-PSCDRV=/epics/modules/pscdrv
-
-NPDPLUGIN=/epics/modules
-AREA_DETECTOR=/epics/modules
-ADCORE=/epics/modules/ADCore
-
+#EPICS_BASE=/usr/lib/epics
 
 # These lines allow developers to override these RELEASE settings
 # without having to modify this file directly.

--- a/nsls2emApp/src/Makefile
+++ b/nsls2emApp/src/Makefile
@@ -7,7 +7,6 @@ include $(TOP)/configure/CONFIG
 # Use typed rset structure (see 3.16.1 release notes)
 USR_CPPFLAGS += -DUSE_TYPED_RSET
 
-
 # Auto-generate a header file containing a version string.
 # Version comes from the VCS if available, else date+time.
 GENVERSION = nsls2emVersion.h
@@ -15,82 +14,29 @@ GENVERSION = nsls2emVersion.h
 GENVERSIONMACRO = nsls2emVERSION
 
 # Build the IOC application
-PROD_IOC = nsls2em
+PROD_NAME = nsls2em
+PROD_IOC_WIN32 += $(PROD_NAME)
+PROD_IOC_Linux += $(PROD_NAME)
 
 # nsls2em.dbd will be created and installed
-DBD += nsls2em.dbd
+DBD += $(PROD_NAME).dbd
 
-# nsls2em.dbd will include these files:
-nsls2em_DBD += base.dbd
-#
-nsls2em_DBD += pscCore.dbd
-nsls2em_DBD += asSupport.dbd
-nsls2em_DBD += drvNSLS2_VEM.dbd
-nsls2em_DBD += asyn.dbd
-nsls2em_DBD += drvAsynIPPort.dbd
-nsls2em_DBD += ADSupport.dbd
-nsls2em_DBD += NDPluginSupport.dbd
-nsls2em_DBD += busySupport.dbd
-nsls2em_DBD += calcSupport.dbd
-nsls2em_DBD += devIocStats.dbd
-nsls2em_DBD += system.dbd
-nsls2em_DBD += caPutLog.dbd
-nsls2em_DBD += caPutLog.dbd
-nsls2em_DBD += NDFileNetCDF.dbd
-nsls2em_DBD += NDFileHDF5.dbd
-nsls2em_DBD += stdSupport.dbd
-nsls2em_DBD += epidRecord.dbd
+$(PROD_NAME)_DBD += base.dbd
+$(PROD_NAME)_DBD += pscCore.dbd
+$(PROD_NAME)_DBD += drvNSLS2_VEM.dbd
+$(PROD_NAME)_DBD += epidRecord.dbd
 
-#
-nsls2em_SRCS += subCalcAlarm.c
-nsls2em_SRCS += drvQuadEM.cpp
-nsls2em_SRCS += drvNSLS2_VEM.cpp
-#nsls2em_SRCS += subCalcAlarm.c
+$(PROD_NAME)_LIBS += std
+$(PROD_NAME)_LIBS += pscCore
 
-#
-nsls2em_LIBS += pscCore
-nsls2em_LIBS += autosave
-nsls2em_LIBS += devIocStats
-nsls2em_LIBS += caPutLog
-
-# asyn and adcore
-nsls2em_LIBS += asyn
-nsls2em_LIBS += NDPlugin
-nsls2em_LIBS += ADBase
-nsls2em_LIBS += busy
-nsls2em_LIBS += calc
-nsls2em_LIBS += std
-
-
+$(PROD_NAME)_SRCS += subCalcAlarm.c
+$(PROD_NAME)_SRCS += drvQuadEM.cpp
+$(PROD_NAME)_SRCS += drvNSLS2_VEM.cpp
 
 # nsls2em_registerRecordDeviceDriver.cpp derives from nsls2em.dbd
-nsls2em_SRCS += nsls2em_registerRecordDeviceDriver.cpp
+nsls2em_SRCS += $(PROD_NAME)_registerRecordDeviceDriver.cpp $(PROD_NAME)Main.cpp
 
-# Build the main IOC entry point where needed
-nsls2em_SRCS_DEFAULT += nsls2emMain.cpp
-nsls2em_SRCS_vxWorks += -nil-
-
-# Link in the code from our support library
-# nsls2em_LIBS += nsls2emSupport
-
-# To build SNL programs, SNCSEQ must be defined
-# in the <top>/configure/RELEASE file
-ifneq ($(SNCSEQ),)
-    nsls2em_LIBS += seq pv
-endif
-
-# Link QSRV (pvAccess Server) if available
-ifdef EPICS_QSRV_MAJOR_VERSION
-    nsls2em_LIBS += qsrv
-    nsls2em_LIBS += $(EPICS_BASE_PVA_CORE_LIBS)
-    nsls2em_DBD += PVAServerRegister.dbd
-    nsls2em_DBD += qsrv.dbd
-endif
-
-# Finally link IOC to the EPICS Base libraries
-nsls2em_LIBS += $(EPICS_BASE_IOC_LIBS)
-nsls2em_SYS_LIBS += event_core event_extra
-nsls2em_SYS_LIBS_DEFAULT = event_pthreads
+include $(ADCORE)/ADApp/commonDriverMakefile
 
 include $(TOP)/configure/RULES
 #----------------------------------------


### PR DESCRIPTION
Change the IOC Makefile and configure/CONFIG to work with standard build system.

Custom configurations to build the IOC in test environment should be performed in RELEASE.local and CONFIG_SITE.local files.